### PR TITLE
Remove needless label from graph plots

### DIFF
--- a/scripts/pages/popup.js
+++ b/scripts/pages/popup.js
@@ -303,7 +303,7 @@ function reDrawPopup() {
                     fillAndStroke: true,
                     fillColor: '#ADA',
                     showMarker: false,
-                    pointLabels: { show: true } 
+                    pointLabels: { show: false } 
                 },
                 grid: {
                     drawGridLines: false,


### PR DESCRIPTION
The plot values associated with issue #20 are indeed annoying. The current speed is already shown the graph is more of a trend and has axis labels already
