### PR TITLE
manifest refactor

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -43,8 +43,7 @@
 	],
 	"permissions":
 	[
-		"http://*/*",
-		"https://*/*",
+		"*://*/*",
 		"tabs",
 		"notifications",
 		"contextMenus",
@@ -53,218 +52,87 @@
 	"content_scripts": [
 		{
 			"matches": [
-				"http://*.nzbclub.com/",
-				"http://*.nzbclub.com/*",
-				"https://*.nzbclub.com/",
-				"https://*.nzbclub.com/*",
-				"http://nzbclub.com/*",
-				"https://nzbclub.com/"
+				"*://*.nzbclub.com/*",
+				"*://*.bintube.com/*",
+				"*://*.binsearch.info/*",
+				"*://*.binsearch.net/*",
+				"*://*.binsearch.co.uk/*",
+				"*://*.binsear.ch/*",
+				"*://*.nzbindex.com/*",
+				"*://*.nzbindex.nl/*",
+				"*://*.nzbsrus.com/*",		
+				"*://*.nzb.su/*",
+				"*://*.fanzub.com/*",
+				"*://*.dognzb.cr/*",
+				"*://*.yubse.com/*",
+				"*://*.nzbx.co/*"
 			],
 			"js": [
 				"third_party/jquery/jquery-1.7.2.min.js",
 				"scripts/content/common.js",
-				"scripts/content/nzbclub.js"
+				"third_party/webtoolkit/webtoolkit.base64.js"
 			],
+			"all_frames": true
+		},
+		
+		{
+			"matches": [ "*://*.nzbclub.com/*" ],
+			"js": [	"scripts/content/nzbclub.js" ],
+			"all_frames": true
+		},
+		{
+			"matches": [ "*://*.bintube.com/*" ],
+			"js": [ "scripts/content/bintube.js" ],
 			"all_frames": true
 		},
 		{
 			"matches": [
-				"http://*.bintube.com/",
-				"http://*.bintube.com/*",
-				"https://*.bintube.com/",
-				"https://*.bintube.com/*",
-				"http://bintube.com/*",
-				"https://bintube.com/"
+				"*://*.binsearch.info/*",
+				"*://*.binsearch.net/*",
+				"*://*.binsearch.co.uk/*",
+				"*://*.binsear.ch/*" 				
 			],
-			"js": [
-				"third_party/jquery/jquery-1.7.2.min.js",
-				"scripts/content/common.js",
-				"scripts/content/bintube.js"
-			],
+			"js": [	"scripts/content/binsearch.js" ],
 			"all_frames": true
 		},
 		{
-			"matches": [
-				"http://*.binsearch.info/",
-				"http://*.binsearch.info/*",
-				"https://*.binsearch.info/",
-				"https://*.binsearch.info/*",
-				"http://binsearch.info/",
-				"http://binsearch.info/*",
-				"https://binsearch.info/",
-				"https://binsearch.info/*",
-				"http://*.binsearch.net/",
-				"http://*.binsearch.net/*",
-				"https://*.binsearch.net/",
-				"https://*.binsearch.net/*",
-				"http://binsearch.net/",
-				"http://binsearch.net/*",
-				"https://binsearch.net/",
- 				"https://binsearch.net/*",
- 				"http://*.binsearch.co.uk/",
- 				"http://*.binsearch.co.uk/*",
- 				"https://*.binsearch.co.uk/",
- 				"https://*.binsearch.co.uk/*",
- 				"http://binsearch.co.uk/",
- 				"http://binsearch.co.uk/*",
- 				"https://binsearch.co.uk/",
- 				"https://binsearch.co.uk/*",
- 				"http://*.binsear.ch/",
- 				"http://*.binsear.ch/*",
- 				"https://*.binsear.ch/",
- 				"https://*.binsear.ch/*",
- 				"http://binsear.ch/",
- 				"http://binsear.ch/*",
- 				"https://binsear.ch/",
- 				"https://binsear.ch/*"
+			"matches" : [ 
+				"*://*.nzbindex.com/*",
+				"*://*.nzbindex.nl/*"
 			],
-			"js": [
-				"third_party/jquery/jquery-1.7.2.min.js",
-				"scripts/content/common.js",
-				"scripts/content/binsearch.js"
-			],
+			"js": [	"scripts/content/nzbindex.js" ],
 			"all_frames": true
 		},
 		{
-			"matches": [
-				"http://*.nzbindex.com/",
-				"http://*.nzbindex.com/*",
-				"https://*.nzbindex.com/",
-				"https://*.nzbindex.com/*",
-				"http://nzbindex.com/",
-				"http://nzbindex.com/*",
-				"https://nzbindex.com/",
-				"https://nzbindex.com/*",
-				"http://*.nzbindex.nl/",
-				"http://*.nzbindex.nl/*",
-				"https://*.nzbindex.nl/",
-				"https://*.nzbindex.nl/*",
-				"http://nzbindex.nl/",
-				"http://nzbindex.nl/*",
-				"https://nzbindex.nl/",
-				"https://nzbindex.nl/*"
-			],
-			"js": [
-				"third_party/jquery/jquery-1.7.2.min.js",
-				"scripts/content/common.js",
-				"scripts/content/nzbindex.js"
-			],
+			"matches": [ "*://*.nzbsrus.com/*" ],
+			"js": [	"scripts/content/nzbsrus.js" ],
 			"all_frames": true
 		},
 		{
-			"matches": [
-				"http://*.nzbsrus.com/",
-				"http://*.nzbsrus.com/*",
-				"https://*.nzbsrus.com/",
-				"https://*.nzbsrus.com/*",
-				"http://nzbsrus.com/",
-				"http://nzbsrus.com/*",
-				"https://nzbsrus.com/",
-				"https://nzbsrus.com/*"
-			],
-			"js": [
-				"third_party/jquery/jquery-1.7.2.min.js",
-				"scripts/content/common.js",
-				"third_party/webtoolkit/webtoolkit.base64.js",
-				"scripts/content/nzbsrus.js"
-			],
+			"matches": [ "*://*.nzb.su/*" ],
+			"js": [ "scripts/content/nzbdotsu.js" ],
 			"all_frames": true
 		},
 		{
-			"matches": [
-				"http://*.nzb.su/",
-				"http://*.nzb.su/*",
-				"http://nzb.su/",
-				"http://nzb.su/*",
-				"https://*.nzb.su/",
-				"https://*.nzb.su/*",
-				"https://nzb.su/",
-				"https://nzb.su/*"
-			],
-			"js": [
-				"third_party/jquery/jquery-1.7.2.min.js",
-				"scripts/content/common.js",
-				"third_party/webtoolkit/webtoolkit.base64.js",
-				"scripts/content/nzbdotsu.js"
-			],
+			"matches": [ "*://*.fanzub.com/*" ],
+			"js": [	"scripts/content/fanzub.js"	],
 			"all_frames": true
 		},
 		{
-			"matches": [
-				"http://*.fanzub.com/",
-				"http://*.fanzub.com/*",
-				"http://fanzub.com/",
-				"http://fanzub.com/*",
-				"https://*.fanzub.com/",
-				"https://*.fanzub.com/*",
-				"https://fanzub.com/",
-				"https://fanzub.com/*"
-			],
-			"js": [
-				"third_party/jquery/jquery-1.7.2.min.js",
-				"scripts/content/common.js",
-				"third_party/webtoolkit/webtoolkit.base64.js",
-				"scripts/content/fanzub.js"
-			],
+			"matches": [ "*://*.dognzb.cr/*" ],
+			"js": [	"scripts/content/dognzb.js"	],
 			"all_frames": true
 		},
 		{
-			"matches": [
-				"http://*.dognzb.cr/",
-				"http://*.dognzb.cr/*",
-				"http://dognzb.cr/",
-				"http://dognzb.cr/*",
-				"https://*.dognzb.cr/",
-				"https://*.dognzb.cr/*",
-				"https://dognzb.cr/",
-				"https://dognzb.cr/*"
-			],
-			"js": [
-				"third_party/jquery/jquery-1.7.2.min.js",
-				"scripts/content/common.js",
-				"third_party/webtoolkit/webtoolkit.base64.js",
-				"scripts/content/dognzb.js"
-			],
+			"matches": [ "*://*.yubse.com/*" ],
+			"js": [ "scripts/content/yubse.js" ],
 			"all_frames": true
 		},
 		{
-			"matches": [ 
-				"http://*.yubse.com/", 
-				"http://*.yubse.com/*", 
-				"http://yubse.com/", 
-				"http://yubse.com/*", 
-				"https://*.yubse.com/", 
-				"https://*.yubse.com/*", 
-				"https://yubse.com/", 
-				"https://yubse.com/*", 
-				"http://beta.yubse.com/*"
-			],
-			"js": [ 
-				"third_party/jquery/jquery-1.7.2.min.js", 
-				"scripts/content/common.js", 
-				"third_party/webtoolkit/webtoolkit.base64.js", 
-				"scripts/content/yubse.js" 
-			],
-			"all_frames": true
-		},
-		{
-			"matches": [ 
-				"http://*.nzbx.co/", 
-				"http://*.nzbx.co/*", 
-				"http://nzbx.co/", 
-				"http://nzbx.co/*",
-				"https://*.nzbx.co/", 
-				"https://*.nzbx.co/*", 
-				"https://nzbx.co/", 
-				"https://nzbx.co/*"
-			],
-			"js": [ 
-				"third_party/jquery/jquery-1.7.2.min.js", 
-				"scripts/content/common.js", 
-				"third_party/webtoolkit/webtoolkit.base64.js", 
-				"scripts/content/nzbx.js" 
-			],
+			"matches": [ "*://*.nzbx.co/*" ],
+			"js": [	"scripts/content/nzbx.js" ],
 			"all_frames": true
 		}
+		
 	]
 }


### PR DESCRIPTION
The manifest was looking a bit unwieldy so I scratched that itch. A lot of the domain patterns were redundant. Also moved jquery, common, and webtoolkit to an initial common matched block to reduce redundancy there. 

I'd give it about 98% I don't have a domain typo.

https://developer.chrome.com/extensions/match_patterns.html
