### PR TITLE
Correct the tab we inject our code to when Newznab is triggered

### DIFF
--- a/scripts/pages/newznab-check.js
+++ b/scripts/pages/newznab-check.js
@@ -7,21 +7,21 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
         for (var i = 0; i < newznab_urls.length; i++) {
             var newznab_url = newznab_urls[i];
             if (tab.url.match('https?://.*' + newznab_url.trim() + '.*')) {
-                chrome.tabs.executeScript(null, {file: "third_party/jquery/jquery-1.7.2.min.js"});
-                chrome.tabs.executeScript(null, {file: "scripts/content/common.js"});
-                chrome.tabs.executeScript(null, {file: "third_party/webtoolkit/webtoolkit.base64.js"});
-                chrome.tabs.executeScript(null, {file: "scripts/content/newznab.js"});
-                chrome.tabs.insertCSS(null, {file: "css/newznab.css"});
+                chrome.tabs.executeScript(tabId, {file: "third_party/jquery/jquery-1.7.2.min.js"});
+                chrome.tabs.executeScript(tabId, {file: "scripts/content/common.js"});
+                chrome.tabs.executeScript(tabId, {file: "third_party/webtoolkit/webtoolkit.base64.js"});
+                chrome.tabs.executeScript(tabId, {file: "scripts/content/newznab.js"});
+                chrome.tabs.insertCSS(tabId, {file: "css/newznab.css"});
                 found_nab = true;
                 break;
             }
         }
         if ( (!found_nab) && (tab.url.indexOf('http') == 0) ) {
-            chrome.tabs.executeScript(null, {file: "third_party/jquery/jquery-1.7.2.min.js"});
-            chrome.tabs.executeScript(null, {file: "third_party/jquery/jquery.notify.js"});
-            chrome.tabs.executeScript(null, {file: "scripts/content/common.js"});
-            chrome.tabs.executeScript(null, {file: "scripts/pages/newznab-autoadd.js"});
-            chrome.tabs.insertCSS(null, {file: "css/nabnotify.css"});
+            chrome.tabs.executeScript(tabId, {file: "third_party/jquery/jquery-1.7.2.min.js"});
+            chrome.tabs.executeScript(tabId, {file: "third_party/jquery/jquery.notify.js"});
+            chrome.tabs.executeScript(tabId, {file: "scripts/content/common.js"});
+            chrome.tabs.executeScript(tabId, {file: "scripts/pages/newznab-autoadd.js"});
+            chrome.tabs.insertCSS(tabId, {file: "css/nabnotify.css"});
         }
     }
 });


### PR DESCRIPTION
chrome.tabs.executeScript was passed null, when it should be the tabId associated with the Newznab window we want.

This optional parameter will inject the the code into the current tab when set to null, which may not be a Newznab window.

Example:
- Load a.n.newznab website in tab 1
- Type a.n.newznab address in a second tab
- Immediately switch to the first tab on hitting enter

The result is that you will see multiple sab links for the listed downloads, but tab 2 has none. Repeat steps two & three and watch the links grow in tab 1. tabId ensures we inject to the window the load event occurred in.
