### PR TITLE
Newznab cleanup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,7 @@
 	"background": {
 			"scripts": [
 				"third_party/jquery/jquery-1.7.2.min.js",
+				"third_party/jquery/jquery.urldecoder.min.js",
 				"third_party/fancy-settings/lib/store.js",
 				"scripts/convert.js",
 				"scripts/utility.js",

--- a/scripts/pages/newznab-autoadd.js
+++ b/scripts/pages/newznab-autoadd.js
@@ -8,50 +8,61 @@
         config automatically if requested.
     */
 
-    // Lets restrict our movements to pages that are newznab, logged in and displaying triggerable data
-    if ( ($('[name=RSSTOKEN]').filter(':first').length) &&
+    var newznabDetection = function(){
+        // Lets try and wrap all detection functions to a simplistic block
+        var runFound = false;
+
+        // most sites detect here
+        if ( ($('[name=RSSTOKEN]').filter(':first').length) &&
             ($('input.nzb_multi_operations_cart').filter(':first').length) )
-    {
+        { return true; }
+
+        // some additionals
+        $('#browsetable tr:gt(0)').filter(':first').each(function() {
+            if ( $(this).find('td.item label').filter(':first').length )
+                runFound = true;
+        });
+        if ( runFound )
+            return true;
+
+        // If all else fails, we are not sab ;)
+        return false;
+    }
+
+    // Lets restrict our movements to pages that are newznab, logged in and displaying triggerable data
+    if ( newznabDetection() ) {
         var thishost = (window.location.hostname.match(/([^.]+)\.\w{2,3}(?:\.\w{2})?$/) || [])[0];
-        var request = {
+        $('body').prepend(
+           $('<div>').addClass('notification autonabSticky hide').prepend(
+                $('<p>Sabconnect++ can setup to work with this site. What would you like to do:</p>').append(
+                    ' <a href="javascript:" id="autonabEnable">Enable</a> | <a href="javascript:" id="autonabIgnore">Ignore</a>'
+                ),
+                $('<a class="close" href="javascript:"><div class="autonabStickyClose"></div></a>')
+            )
+        );
+        $('.notification.autonabSticky').notify();
+        $('#autonabIgnore').click(function(){
+            var request = {
+                action: 'set_setting',
+                setting: 'nabignore.' + thishost,
+                value: true
+            };
+            chrome.extension.sendMessage( request );
+            $('a.close').click();
+        });
+        $('#autonabEnable').click(function(){
+            var request = {
                 action: 'get_setting',
-                setting: 'nabignore.' + thishost
-        };
-        chrome.extension.sendMessage( request, function( response ) {
-            if ( response.value == true )
-                return;
-            $('body').prepend(
-                $('<div>').addClass('notification autonabSticky hide').prepend(
-                    $('<p>Sabconnect++ can setup to work with this site. What would you like to do:</p>').append(
-                        ' <a href="javascript:" id="autonabEnable">Enable</a> | <a href="javascript:" id="autonabIgnore">Ignore</a>'
-                    ),
-                    $('<a class="close" href="javascript:"><div class="autonabStickyClose"></div></a>')
-                )
-            );
-            $('.notification.autonabSticky').notify();
-            $('#autonabIgnore').click(function(){
+                setting: 'provider_newznab'
+            };
+            chrome.extension.sendMessage( request, function( response ) {
                 var request = {
                     action: 'set_setting',
-                    setting: 'nabignore.' + thishost,
-                    value: true
+                    setting: 'provider_newznab',
+                    value: response.value + ', ' + thishost
                 };
-                chrome.extension.sendMessage( request );
-                $('a.close').click();
-            });
-            $('#autonabEnable').click(function(){
-                var request = {
-                    action: 'get_setting',
-                    setting: 'provider_newznab'
-                };
-                chrome.extension.sendMessage( request, function( response ) {
-                    var request = {
-                        action: 'set_setting',
-                        setting: 'provider_newznab',
-                        value: response.value + ', ' + thishost
-                    };
-                    chrome.extension.sendMessage( request, function() {
-                        location.reload();
-                    });
+                chrome.extension.sendMessage( request, function() {
+                    location.reload();
                 });
             });
         });

--- a/scripts/pages/newznab-check.js
+++ b/scripts/pages/newznab-check.js
@@ -4,6 +4,8 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     if (changeInfo.status == 'complete') {
         var found_nab = false;
         var newznab_urls = store.get('provider_newznab').split(',');
+        var parsedurl = $.url.parse( tab.url );
+        var host = (parsedurl.host.match(/([^.]+)\.\w{2,3}(?:\.\w{2})?$/) || [])[0]
         for (var i = 0; i < newznab_urls.length; i++) {
             var newznab_url = newznab_urls[i];
             if (tab.url.match('https?://.*' + newznab_url.trim() + '.*')) {
@@ -12,16 +14,23 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
                 chrome.tabs.executeScript(tabId, {file: "third_party/webtoolkit/webtoolkit.base64.js"});
                 chrome.tabs.executeScript(tabId, {file: "scripts/content/newznab.js"});
                 chrome.tabs.insertCSS(tabId, {file: "css/newznab.css"});
+                if ( store.get( 'nabignore.' + host ) === false )
+                    store.set( 'nabignore.' + host );
                 found_nab = true;
                 break;
             }
         }
         if ( (!found_nab) && (tab.url.indexOf('http') == 0) ) {
-            chrome.tabs.executeScript(tabId, {file: "third_party/jquery/jquery-1.7.2.min.js"});
-            chrome.tabs.executeScript(tabId, {file: "third_party/jquery/jquery.notify.js"});
-            chrome.tabs.executeScript(tabId, {file: "scripts/content/common.js"});
-            chrome.tabs.executeScript(tabId, {file: "scripts/pages/newznab-autoadd.js"});
-            chrome.tabs.insertCSS(tabId, {file: "css/nabnotify.css"});
+            var nabenabled = store.get( 'nabignore.' + host );
+            if ( !nabenabled ) {
+                chrome.tabs.executeScript(tabId, {file: "third_party/jquery/jquery-1.7.2.min.js"});
+                chrome.tabs.executeScript(tabId, {file: "third_party/jquery/jquery.notify.js"});
+                chrome.tabs.executeScript(tabId, {file: "scripts/content/common.js"});
+                chrome.tabs.executeScript(tabId, {file: "scripts/pages/newznab-autoadd.js"});
+                chrome.tabs.insertCSS(tabId, {file: "css/nabnotify.css"});
+            }
+            if ( nabenabled === false )
+                store.set( 'nabignore.' + host );
         }
     }
 });


### PR DESCRIPTION
Improved the detection which means usenet-crawler should work now, on the same pages that the actual newznab does.

There are other areas this can be improved though, but I don't have access to many newznab services.

Page injection has been improved slightly. We are still importing to every unknown page (I can see a new option coming along I think), as well as excluding enabled newznab pages, but we not don't import to ignored pages.

The usenet-crawler integration has however highlighted my ever poor design skills. CSS from the parent page gives for a very poor experience, with different font sizes and colours, rendering this push potentially "not fit for purpose".
