### PR TITLE
Nzbx

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 0.6.3
+Improvement: Added multi-select to nzbx.co
+Bugfix: nzbx.co no category failure fixed
+
 Version 0.6.2
 -------------
 Re-added: dognzb.cr

--- a/scripts/content/nzbx.js
+++ b/scripts/content/nzbx.js
@@ -57,7 +57,9 @@ function handleAllDownloadLinks() {
 	multi
 		.css("margin-right", 10)
 		.click(addSelected);
-	$("#multi-download").before(multi);
+	$("#multi-download")
+		.before(multi)
+		.parents("div").first().css("width", "auto");
 }
 
 function RefreshSettings()


### PR DESCRIPTION
Moves the single link to next to the checkboxes. Makes use of the new(ish) checkboxes for mult-select. Handles category safer, was failing on no category. Layout is a bit inconsistent between browse and search, but basic fix tossed in I'd rather avoid but needed for now.
