### PR TITLE
Added ignore categories option. This prevents SABConnect++ from sending ...

### DIFF
--- a/scripts/content/common.js
+++ b/scripts/content/common.js
@@ -1,3 +1,5 @@
+var ignoreCats;
+
 function onResponseAdd( response, addLink )
 {
 	switch( response.ret ) {
@@ -61,7 +63,10 @@ function addToSABnzbd(addLink, nzburl, mode, nice_name, category) {
 		request.nzbname = nice_name;
 	}
 
-	if (typeof category != 'undefined' && category != null) {
+	GetSetting('config_ignore_categories', function( value ) {
+		ignoreCats = value;
+	});
+	if (!ignoreCats && typeof category != 'undefined' && category != null) {
 		request.category = category;
 	}
 	

--- a/scripts/content/newznab.js
+++ b/scripts/content/newznab.js
@@ -3,6 +3,10 @@
 
 	var queryString = '?i=' + $('[name=UID]').val() + '&r=' + $('[name=RSSTOKEN]').val() + '&del=1',
 		oneClickImgTag = '<img style="vertical-align:baseline" src="' + chrome.extension.getURL('/images/sab2_16.png') + '" />';
+    var ignoreCats;
+    GetSetting('config_ignore_categories', function( value ) {
+        ignoreCats = value;
+    });
 			
 	function addMany(e) {
 	
@@ -36,11 +40,13 @@
 		}
 		
 		var category = null;
-		if ($.trim($tr.parent().find('tr:nth-child(1)').find('th:nth-child(2)').text().toLowerCase()) == 'category') {
-		    category = $.trim($tr.find('td:nth-child(2) a').text().match(/^\s*([^> -]+)/)[1]);
-		} else if ($.trim($tr.parent().find('tr:nth-child(1)').find('th:nth-child(3)').text().toLowerCase()) == 'category') {
-		    category = $.trim($tr.find('td:nth-child(3) a').text().match(/^\s*([^> -]+)/)[1]);
-		}
+        if (!ignoreCats) {
+    		if ($.trim($tr.parent().find('tr:nth-child(1)').find('th:nth-child(2)').text().toLowerCase()) == 'category') {
+    		    category = $.trim($tr.find('td:nth-child(2) a').text().match(/^\s*([^> -]+)/)[1]);
+    		} else if ($.trim($tr.parent().find('tr:nth-child(1)').find('th:nth-child(3)').text().toLowerCase()) == 'category') {
+    		    category = $.trim($tr.find('td:nth-child(3) a').text().match(/^\s*([^> -]+)/)[1]);
+    		}
+        }
 		
 		addToSABnzbd(
 			$anchor.get(0),

--- a/scripts/pages/background.js
+++ b/scripts/pages/background.js
@@ -24,6 +24,7 @@ var defaultSettings = {
 	config_enable_context_menu: true,
 	config_enable_notifications: true,
 	config_notification_timeout: 10,
+	config_ignore_categories: false,
     config_use_user_categories: false,
 	config_use_category_header: false,
 	config_hard_coded_category: '',

--- a/scripts/pages/manifest.js
+++ b/scripts/pages/manifest.js
@@ -310,6 +310,15 @@ this.manifest = {
 					'Below are the category settings provided by SABconnect++. For more information regarding categories,\
 					please read the <a href="http://code.google.com/p/sabconnectplusplus/wiki/Categories">wiki page</a>.'
 		},
+		{
+			'tab': 'Configuration',
+			'group': 'Categories',
+			'name': 'config_ignore_categories',
+			'type': 'checkbox',
+			'label': 'Do not attempt to pass category names, forcing SABnzbd to use group names in the NZB instead.\
+					 This will ignore <b>all</b> of the following category options. Note that some indexers (newznab, etc.)\
+					 embed category names in the nzb itself.'
+		},
         {
             'tab': 'Configuration',
             'group': 'Categories',


### PR DESCRIPTION
...the categories to SABNzbd and instead lets SABNzbd rely on the group fields in the actual NZB. Default is disabled so everything will work as before.

This provides much easier auto-categorization for many sites such as nzbindex and binsearch. Some sites (newznab at least) embed category information in NZBs, so SABnzbd still won't fall back to group names. This made things world's easier for me, but it's up to you if you want to include it.
