### PR TITLE
Fix download icon on dognzb.

### DIFF
--- a/scripts/content/dognzb.js
+++ b/scripts/content/dognzb.js
@@ -79,6 +79,7 @@ function handleAllDownloadLinks() {
 		var img = chrome.extension.getURL('images/sab2_16.png');
 		newlink.css('background-image', 'url('+img+')');
 		newlink.css('background-position', '0 0');
+		newlink.css('background-size', 'inherit');
 		
 		// Extract NZB id from onClick and set to ID attribute
 		


### PR DESCRIPTION
The newly specified background-size CSS causes the icon to become incorrectly scaled. This explicitly resets the size to inherit.
