### PR TITLE
Option to disable Newznab auto detection

### DIFF
--- a/scripts/pages/background.js
+++ b/scripts/pages/background.js
@@ -31,6 +31,7 @@ var defaultSettings = {
 	config_hard_coded_category: '',
 	config_default_category: '',
 	config_enable_automatic_authentication: true,
+	config_enable_automatic_detection: true,
 	profiles: {},
 	first_profile_initialized: false,
     active_category: '*',

--- a/scripts/pages/manifest.js
+++ b/scripts/pages/manifest.js
@@ -302,6 +302,13 @@ this.manifest = {
 		{
 			'tab': 'Configuration',
 			'group': 'General',
+			'name': 'config_enable_automatic_detection',
+			'type': 'checkbox',
+			'label': 'Enable Automatic Newznab Detection (can slow down some sites)'
+		},
+		{
+			'tab': 'Configuration',
+			'group': 'General',
 			'name': 'config_reset',
 			'type': 'button',
 			'label': 'Click to reset all settings to default:',

--- a/scripts/pages/newznab-check.js
+++ b/scripts/pages/newznab-check.js
@@ -25,7 +25,8 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
         }
         if ( (!found_nab) && (tab.url.indexOf('http') == 0) ) {
             var nabenabled = store.get( 'nabignore.' + host );
-            if ( !nabenabled ) {
+            var nabdetection = store.get('config_enable_automatic_detection');
+            if ( nabdetection && !nabenabled ) {
                 chrome.tabs.executeScript(tabId, {file: "third_party/jquery/jquery-1.7.2.min.js"});
                 chrome.tabs.executeScript(tabId, {file: "third_party/jquery/jquery.notify.js"});
                 chrome.tabs.executeScript(tabId, {file: "scripts/content/common.js"});


### PR DESCRIPTION
a fix for https://github.com/gboudreau/sabconnectplusplus/issues/117
Newznab auto detection can cause some sites to slow down, for example Google Slides.
Add a configuration item to disable auto detection.
