### PR TITLE
fix new nzbclub interface (closes #129)

### DIFF
--- a/scripts/content/nzbclub.js
+++ b/scripts/content/nzbclub.js
@@ -2,20 +2,20 @@ function addToSABnzbdFromNZBCLUB() {
     // Set the image to an in-progress image
     var img = chrome.extension.getURL('images/sab2_16_fetching.png');
     $(this).find('img').first().attr("src", img);
-    
+
     var nzburl = $(this).attr('href');
     var addLink = $(this).parent();
-    	
+
     addToSABnzbd(addLink, nzburl, "addurl");
-    
+
     return false;
 }
 
 function handleAllDownloadLinks() {
-	$('span[id^="ctl00_ContentPlaceHolder2_RadGrid1_ctl00_ctl"][id$="_ui_sizelabel"]').each(function() {
+	$('div.project-action > div > button[id="get"]').each(function() {
 	    var img = chrome.extension.getURL('/images/sab2_16.png');
-	    var href = $(this).find('a').attr('href');
-	    var link = '<span><a class="addSABnzbd" href="' + href + '"><img title="Send to SABnzbd" src="' + img + '" /> To SAB</a><br/></span>';
+	    var href = "https://www.nzbclub.com/nzb_get/" + $(this).parent().parent().attr('collectionid');
+	    var link = '<a class="btn btn-xs btn-warning addSABnzbd" href="' + href + '"><img style="margin-top: auto; width: 14px; height: 14px; border-radius: 0%; margin-bottom: auto;" title="Send to SABnzbd" src="' + img + '" /> To SAB</a>';
 	    $(this).after(link);
 		$(this).parent().find('a[class="addSABnzbd"]').first().click(addToSABnzbdFromNZBCLUB);
 	});


### PR DESCRIPTION
nzbclub changed there weblayout, so the nzbclub-integration lost functionality.

Fixed the script for the new interface and used there stylesheets:

![button](https://cloud.githubusercontent.com/assets/823072/8193089/fc022974-1472-11e5-9180-4632c78af2a4.jpg)

will actually close #129 