### PR TITLE
#137 Adding external message listener

### DIFF
--- a/scripts/pages/background.js
+++ b/scripts/pages/background.js
@@ -586,6 +586,7 @@ function initializeProfile()
 function initializeBackgroundPage()
 {
 	chrome.extension.onMessage.addListener( OnRequest );
+	chrome.runtime.onMessageExternal.addListener( OnRequest );
 
     // Migration from localStorage to chrome.storage.sync
 	var settingsSynced = store.get( 'settings_synced' );


### PR DESCRIPTION
By adding this listener for external messages, we allow for other extensions or web pages themselves to send messages to the SabConnect++ extension. 

This is for example useful when sabnzbd links are injected dynamically by another extension. Since the links on a webpage are only analysed once right after the page is loaded, any content that has been inject dynamically at a later stage won't be analysed and won't be sent to the SabConnect++ extension. Therefore, it would be useful if the other extension is able to send the 'addToSabnzbd' message manually to the SabConnect++ extension.
