### PR TITLE
Change getNzbId() regex to match longer nzbId

### DIFF
--- a/scripts/content/omgwtfnzbs.js
+++ b/scripts/content/omgwtfnzbs.js
@@ -1,5 +1,5 @@
 function getNzbId(elem) {
-	var match = /\?id=([0-9a-zA-Z]{5})/i.exec(elem);
+	var match = /\?id=([0-9a-zA-Z]{5,6})/i.exec(elem);
 	
 	if (typeof match != 'undefined' && match != null) {
 		var nzbId = match[1];


### PR DESCRIPTION
nzbId length has increased on site from 5 to 6 so we need to catch both cases.