### PR TITLE
Enable context menu on https pages

### DIFF
--- a/scripts/pages/context_menu.js
+++ b/scripts/pages/context_menu.js
@@ -34,7 +34,8 @@ function CreateContextMenuResult()
 function CreateContextMenu()
 {
 	var urlPatterns = [
-		'http://*/*'
+		'http://*/*',
+		'https://*/*'
 	]
 	
 	var properties = {


### PR DESCRIPTION
Previously the context menu, if enabled, would only appear on http pages. The url pattern is now updated to include https.