### PR TITLE
updated common.js to handle new dognzb download server url

### DIFF
--- a/scripts/content/common.js
+++ b/scripts/content/common.js
@@ -50,7 +50,11 @@ function onResponseAdd( response, addLink )
 function addToSABnzbd(addLink, nzburl, mode, nice_name, category) {
 	
 	if(nzburl.substring(0, 1) == "/") {
-		nzburl = window.location.protocol + "//" + window.location.host + nzburl;
+		var locHost = window.location.host;
+		if (locHost == "dognzb.cr") {
+			locHost = "dl.dognzb.cr";
+		}
+		nzburl = window.location.protocol + "//" + locHost + nzburl;
 	}
 	
 	var request = {


### PR DESCRIPTION
Dognzb added a new server specifically to handle downloads and hence now uses dl.dognzb.cr. The extension was failing when pulling NZB since it was just getting the base URL. Testing these changes seemed to fix the underlying problem.