### PR TITLE
Updated all chrome.extension calls that have been deprecated

### DIFF
--- a/scripts/content/animenzb.js
+++ b/scripts/content/animenzb.js
@@ -2,7 +2,7 @@ function addToSABnzbdFromAnimenzb() {
 	var addLink = this;
 	
 	// Set the image to an in-progress image
-	var img = chrome.extension.getURL('images/sab2_16_fetching.png');
+	var img = chrome.runtime.getURL('images/sab2_16_fetching.png');
 	var nzburl = this.href;
 
 	var category = null;
@@ -20,7 +20,7 @@ function handleAllDownloadLinks() {
         // Find all Table Rows - $('td.file > a[type="application/x-nzb"]').parent().parent()
         // Find all Download links - $('td.file > a[type="application/x-nzb"]')
 	$('td.file > a[type="application/x-nzb"]').each(function() {
-		var img = chrome.extension.getURL('/images/sab2_16.png');
+		var img = chrome.runtime.getURL('/images/sab2_16.png');
 		var href = $(this).attr('href');
 		var link = '<a class="addSABnzbd" href="' + href + '"><img title="Send to SABnzbd" src="' + img + '" /></a>&nbsp;';
 		$(this).before(link);

--- a/scripts/content/animezb.js
+++ b/scripts/content/animezb.js
@@ -2,7 +2,7 @@ function addToSABnzbdFromAnimezb() {
 	var addLink = this;
 	
     // Set the image to an in-progress image
-    var img = chrome.extension.getURL('images/sab2_16_fetching.png');
+    var img = chrome.runtime.getURL('images/sab2_16_fetching.png');
 	var nzburl = this.href;
 
 	var category = null;
@@ -30,7 +30,7 @@ function addMultiToSABnzbdFromAnimezb() {
 
 function handleAllDownloadLinks() {
 	$('table[id="search-results"] td:nth-child(2) a').each(function() {
-	    var img = chrome.extension.getURL('/images/sab2_16.png');
+	    var img = chrome.runtime.getURL('/images/sab2_16.png');
 	    var href = $(this).attr('href');
 	    var link = '<a class="addSABnzbd" href="' + href + '"><img title="Send to SABnzbd" src="' + img + '" /></a>&nbsp;&nbsp;';
 	    $(this).before(link);
@@ -40,7 +40,7 @@ function handleAllDownloadLinks() {
 
 function addDownloadAllButton() {
 	$('div[class=row] form button[class*="btn-sm"]').each(function() {
-	    var img = chrome.extension.getURL('/images/sab2_16.png');
+	    var img = chrome.runtime.getURL('/images/sab2_16.png');
 	    var href = $(this).attr('href');
 	    var link = '<input type="button" id="addMultiSABnzbd" value="Send to SABnzbd" class="btn btn-sm btn-primary" style="width:120px">';
 	    $(this).after(link);

--- a/scripts/content/binsearch.js
+++ b/scripts/content/binsearch.js
@@ -18,7 +18,7 @@ function oneClick() {
 function addOne(addLink) {
 	var $addLink = $(addLink);
     // Set the image to an in-progress image
-    var img = chrome.extension.getURL('images/sab2_16_fetching.png');
+    var img = chrome.runtime.getURL('images/sab2_16_fetching.png');
 	if ($addLink.find('img').length > 0) {
 	    $addLink.find('img').attr("src", img);
 	} else {
@@ -43,7 +43,7 @@ function addOne(addLink) {
 }
 
 function handleAllDownloadLinks() {
-	var img = chrome.extension.getURL('/images/sab2_16.png');
+	var img = chrome.runtime.getURL('/images/sab2_16.png');
 
 	$(".xMenuT input[type=checkbox]").each(function() {
 		var href = '/?action=nzb&' + $(this).attr("name") + '=1';

--- a/scripts/content/bintube.js
+++ b/scripts/content/bintube.js
@@ -1,6 +1,6 @@
 function addToSABnzbdFromBintube() {
     // Set the image to an in-progress image
-    var img = chrome.extension.getURL('images/sab2_16_fetching.png');
+    var img = chrome.runtime.getURL('images/sab2_16_fetching.png');
     $(this).find('img').attr("src", img);
     
     var nzburl = $(this).attr('href');
@@ -14,7 +14,7 @@ function addToSABnzbdFromBintube() {
 function handleAllDownloadLinks() {
 	$('a.dlbtn').each(function() {
 		var href = $(this).attr('href');
-		var img = chrome.extension.getURL('/images/sab2_16.png');
+		var img = chrome.runtime.getURL('/images/sab2_16.png');
 		var link = '<a class="addSABnzbd" href="' + href + '"><img src="' + img + '" /></a> ';
 		$(this).before(link);
 		$(this).remove();

--- a/scripts/content/common.js
+++ b/scripts/content/common.js
@@ -5,7 +5,7 @@ function onResponseAdd( response, addLink )
 	switch( response.ret ) {
 	case 'error' :
 		alert("Could not contact SABnzbd \n Check it is running and your settings are correct");
-		var img = chrome.extension.getURL('images/sab2_16_red.png');
+		var img = chrome.runtime.getURL('images/sab2_16_red.png');
 		if ($(addLink).find('img').length > 0) {
 			$(addLink).find('img').attr("src", img);
 		} else {
@@ -19,7 +19,7 @@ function onResponseAdd( response, addLink )
 		// If there was an error of some type, report it to the user and abort!
 		if (response.data.error) {
 			alert(response.data.error);
-			var img = chrome.extension.getURL('images/sab2_16_red.png');
+			var img = chrome.runtime.getURL('images/sab2_16_red.png');
 			if ($(addLink).find('img').length > 0) {
 				$(addLink).find('img').attr("src", img);
 			} else {
@@ -30,7 +30,7 @@ function onResponseAdd( response, addLink )
 			}
 			return;
 		}
-		var img = chrome.extension.getURL('images/sab2_16_green.png');
+		var img = chrome.runtime.getURL('images/sab2_16_green.png');
 		if ($(addLink).find('img').length > 0) {
 			$(addLink).find('img').attr("src", img);
 		} else if (addLink.nodeName && addLink.nodeName.toUpperCase() == 'INPUT' && addLink.value == 'Sent to SABnzbd!') {
@@ -77,7 +77,7 @@ function addToSABnzbd(addLink, nzburl, mode, nice_name, category) {
 	console.log("Sending to SABnzbd:");
 	console.log(request);
 	
-	chrome.extension.sendMessage(
+	chrome.runtime.sendMessage(
 		request,
 		function(response) { onResponseAdd( response, addLink ) }
 		);
@@ -90,7 +90,7 @@ function GetSetting( setting, callback )
 		setting: setting
 	}
 	
-	chrome.extension.sendMessage( request, function( response ) {
+	chrome.runtime.sendMessage( request, function( response ) {
 		var value = response.value;
 		
 		if( typeof value == 'undefined' || value == null ) {
@@ -118,7 +118,7 @@ function Initialize( provider, refresh_function, callback )
 		provider: provider
 	}
 		
-	chrome.extension.sendMessage( request, function( response ) {
+	chrome.runtime.sendMessage( request, function( response ) {
 		if( response.enabled ) {
 			callback();
 		}
@@ -140,4 +140,4 @@ function OnRequest( request, sender, onResponse )
 	}
 };
 
-chrome.extension.onMessage.addListener( OnRequest );
+chrome.runtime.onMessage.addListener( OnRequest );

--- a/scripts/content/dognzb.js
+++ b/scripts/content/dognzb.js
@@ -43,7 +43,7 @@ function addToSABnzbdFromDognzb() {
 		nzburl = findNZBId(this);
 		if (nzburl) {
 			// Set the image to an in-progress image
-			var img = chrome.extension.getURL('images/sab2_16_fetching.png');
+			var img = chrome.runtime.getURL('images/sab2_16_fetching.png');
 			$(this).css('background-image', 'url('+img+')');
 
 			var tr = $(this).parent().parent();
@@ -76,7 +76,7 @@ function handleAllDownloadLinks() {
 		newlink.addClass('dog-icon-download').addClass('sabcpp-fake-dognzb-marker');
 
 		// Change the nzb download image
-		var img = chrome.extension.getURL('images/sab2_16.png');
+		var img = chrome.runtime.getURL('images/sab2_16.png');
 		newlink.css('background-image', 'url('+img+')');
 		newlink.css('background-position', '0 0');
 		newlink.css('background-size', 'inherit');

--- a/scripts/content/fanzub.js
+++ b/scripts/content/fanzub.js
@@ -2,7 +2,7 @@ function addToSABnzbdFromFanzub() {
 	var addLink = this;
 	
     // Set the image to an in-progress image
-    var img = chrome.extension.getURL('images/sab2_16_fetching.png');
+    var img = chrome.runtime.getURL('images/sab2_16_fetching.png');
 	var nzburl = this.href;
 
 	var category = null;
@@ -29,7 +29,7 @@ function addMultiToSABnzbdFromFanzub() {
 
 function handleAllDownloadLinks() {
 	$('table[class="fanzub"] td[class="file"] a').each(function() {
-	    var img = chrome.extension.getURL('/images/sab2_16.png');
+	    var img = chrome.runtime.getURL('/images/sab2_16.png');
 	    var href = $(this).attr('href');
 	    var link = '<a class="addSABnzbd" href="' + href + '"><img title="Send to SABnzbd" src="' + img + '" /></a>&nbsp;&nbsp;';
 	    $(this).before(link);
@@ -39,7 +39,7 @@ function handleAllDownloadLinks() {
 
 function addDownloadAllButton() {
 	$('table[class="nav"] td button').each(function() {
-	    var img = chrome.extension.getURL('/images/sab2_16.png');
+	    var img = chrome.runtime.getURL('/images/sab2_16.png');
 	    var href = $(this).attr('href');
 	    var link = '<input type="button" id="addMultiSABnzbd" value="Send to SABnzbd" style="width:120px">';
 	    $(this).after(link);

--- a/scripts/content/newznab.js
+++ b/scripts/content/newznab.js
@@ -2,7 +2,7 @@
 (function() { // Encapsulate
 
 	var queryString = '?i=' + $('[name=UID]').val() + '&r=' + $('[name=RSSTOKEN]').val() + '&del=1',
-		oneClickImgTag = '<img style="vertical-align:baseline" src="' + chrome.extension.getURL('/images/sab2_16.png') + '" />',
+		oneClickImgTag = '<img style="vertical-align:baseline" src="' + chrome.runtime.getURL('/images/sab2_16.png') + '" />',
 		ignoreCats,
 		linkRelAlternate = $('link[rel=alternate]').attr('href');
 
@@ -43,7 +43,7 @@
 		var $anchor = $tr.find('a.addSABnzbd');
 
 		// Set the image to an in-progress image
-		var img = chrome.extension.getURL('images/sab2_16_fetching.png');
+		var img = chrome.runtime.getURL('images/sab2_16_fetching.png');
 
 		if ($($anchor.get(0)).find('img').length > 0) {
 			$($anchor.get(0)).find('img').attr("src", img);

--- a/scripts/content/nzbclub.js
+++ b/scripts/content/nzbclub.js
@@ -1,6 +1,6 @@
 function addToSABnzbdFromNZBCLUB() {
     // Set the image to an in-progress image
-    var img = chrome.extension.getURL('images/sab2_16_fetching.png');
+    var img = chrome.runtime.getURL('images/sab2_16_fetching.png');
     $(this).find('img').first().attr("src", img);
 
     var nzburl = $(this).attr('href');
@@ -13,7 +13,7 @@ function addToSABnzbdFromNZBCLUB() {
 
 function handleAllDownloadLinks() {
 	$('div.project-action > div > button[id="get"]').each(function() {
-	    var img = chrome.extension.getURL('/images/sab2_16.png');
+	    var img = chrome.runtime.getURL('/images/sab2_16.png');
 	    var href = "/nzb_get/" + $(this).parent().parent().attr('collectionid');
 	    var link = '<a class="addSABnzbd" href="' + href + '"><img style="margin-top: auto; width: 14px; height: 14px; border-radius: 0%; margin-bottom: auto;" title="Send to SABnzbd" src="' + img + '" /></a>';
 	    $(this).after(link);

--- a/scripts/content/nzbindex.js
+++ b/scripts/content/nzbindex.js
@@ -4,7 +4,7 @@ function addToSABnzbdFromNzbindex() {
     var addLink = this;
 
     // Set the image to an in-progress image
-    var img = chrome.extension.getURL('images/sab2_16_fetching.png');
+    var img = chrome.runtime.getURL('images/sab2_16_fetching.png');
     if ($(this).find('img').length > 0) {
         $(this).find('img').attr("src", img);
         var nzburl = $(this).attr('href');
@@ -50,7 +50,7 @@ function handleAllDownloadLinks() {
         if ($(this).attr('x-nzbpatched') !== 'true') {
             $(this).attr('x-nzbpatched', 'true');
             // add button to send checked items to SABConnect
-            var img = chrome.extension.getURL('/images/sab2_16.png');
+            var img = chrome.runtime.getURL('/images/sab2_16.png');
             var link = '<input class="addSABnzbd" x-nzbpatched="true" type="button" value="      Download selected" style="background-image: url(' + img + '); background-repeat: no-repeat; background-position: 3px 1px;" />';
             $(this).after(link);
             $(this).parent().find('input[class="addSABnzbd"]').first().click(addToSABnzbdFromNzbindex);
@@ -60,7 +60,7 @@ function handleAllDownloadLinks() {
     $('table a[href*="nzbindex.nl\\/download\\/"]').each(function () {
         if ($(this).attr('x-nzbpatched') !== 'true') {
             $(this).attr('x-nzbpatched', 'true');
-            var img = chrome.extension.getURL('/images/sab2_16.png');
+            var img = chrome.runtime.getURL('/images/sab2_16.png');
             var href = $(this).attr('href');
             var link = $('<a class="addSABnzbdOnClick" x-nzbpatched="true" href="' + href + '"><img title="Send to SABnzbd" src="' + img + '" /></a>');
             $(this).before(link);
@@ -71,7 +71,7 @@ function handleAllDownloadLinks() {
     $('table a[href*="nzbindex.com\\/download\\/"]').each(function () {
         if ($(this).attr('x-nzbpatched') !== 'true') {
             $(this).attr('x-nzbpatched', 'true');
-            var img = chrome.extension.getURL('/images/sab2_16.png');
+            var img = chrome.runtime.getURL('/images/sab2_16.png');
             var href = $(this).attr('href');
             var link = $('<a class="addSABnzbdOnClick" x-nzbpatched="true" href="' + href + '"><img title="Send to SABnzbd" src="' + img + '" /></a> ');
             $(this).before(link);

--- a/scripts/content/nzbrss.js
+++ b/scripts/content/nzbrss.js
@@ -1,6 +1,6 @@
 function addToSABnzbdFromNzbrss() {
     // Set the image to an in-progress image
-    var img = chrome.extension.getURL('images/sab2_16_fetching.png');
+    var img = chrome.runtime.getURL('images/sab2_16_fetching.png');
 
     // Only replace the image if it isn't a Bootstrap button style
     if ($(this).hasClass('btn') == false) {    	
@@ -27,7 +27,7 @@ function handleAllDownloadLinks() {
 		// Prevent it from detecting the NZB link in the Breadcrumbs on the NZB page
 		if ($(this).parents('ul').hasClass('breadcrumb') == false) {
 			var href = $(this).attr('href').replace("/nzb/", "/get/");
-			var img = chrome.extension.getURL('/images/sab2_16.png');
+			var img = chrome.runtime.getURL('/images/sab2_16.png');
 			var link = '<a class="addSABnzbd" href="' + href + '"><img border="0" src="' + img + '" title="Send to SABnzbd" /></a>&nbsp;';
 			$(this).before(link);
 		}

--- a/scripts/content/omgwtfnzbs.js
+++ b/scripts/content/omgwtfnzbs.js
@@ -87,7 +87,7 @@ function addOne(nzbid,cat) {
 	
 function addToSABnzbdFromOmgwtfnzbs() {
     // Set the image to an in-progress image
-    var img = chrome.extension.getURL('images/sab2_16_fetching.png');
+    var img = chrome.runtime.getURL('images/sab2_16_fetching.png');
     $(this).find('img').attr("src", img);
     
     var nzburl = $(this).attr('href');	
@@ -138,7 +138,7 @@ function addToSABnzbdFromOmgwtfnzbs() {
 function handleAllDownloadLinks() {	
 	$('img[src="pics/dload.gif"]').each(function() {		
 		var href = $(this).parent().attr('href');
-		var img = chrome.extension.getURL('/images/sab2_16.png');
+		var img = chrome.runtime.getURL('/images/sab2_16.png');
 		var link_mini = '<a class="addSABnzbd hastip" href="' + href + '" style="position:relative;margin-top:5px;width:16px;"><img border="0" src="' + img + '" title="Send to SABnzbd" /></a>&nbsp;';
 		var link_full = '<a class="addSABnzbd linky hastip" href="' + href + '" style="position:relative;margin-top:5px;width:16px;"><img border="0" src="' + img + '" title="Send to SABnzbd" /> Send to SABnzbd</a>&nbsp;';
 				

--- a/scripts/content/usenet4ever.js
+++ b/scripts/content/usenet4ever.js
@@ -76,7 +76,7 @@ function handleAllDownloadLinks()
     /*
 	$('img[src="http://usenet4ever.info/vb4/posten/images/nzb_link1.png"]').each(function() {
 		// add button to send item to SABConnect
-		var img = chrome.extension.getURL('/images/sab2_16.png');
+		var img = chrome.runtime.getURL('/images/sab2_16.png');
 		var link = '<button class="addToSABnzbd" style="margin:15px;" title="add to SABnzbd"><img src="'+img+'" />add to SABnzbd</button><br/>';
 		$(this).parent('a').before(link);
 		//$(this).parent('a').next('a.addSABnzbd').click(addToSABnzbdFromUsenet4ever);

--- a/scripts/content/yubse.js
+++ b/scripts/content/yubse.js
@@ -2,7 +2,7 @@ var useNiceName;
 
 function addAllToSABnzbdFromYubse() {
 	 // Set the image to an in-progress image
-    var img = chrome.extension.getURL('images/sab2_16_fetching.png');
+    var img = chrome.runtime.getURL('images/sab2_16_fetching.png');
 	if ($(this).find('img').length > 0) {
 	    $(this).find('img').attr("src", img);
 	} else {
@@ -30,7 +30,7 @@ function addAllToSABnzbdFromYubse() {
 
 function addToSABnzbdFromYubse(node) {
 	 // Set the image to an in-progress image
-    var img = chrome.extension.getURL('images/sab2_16_fetching.png');
+    var img = chrome.runtime.getURL('images/sab2_16_fetching.png');
 	if ($(node).find('a[class="addSABnzbd"]').find('img').length > 0) {
 	    $(node).find('a[class="addSABnzbd"]').find('img').attr("src", img);
 	} else {
@@ -54,7 +54,7 @@ function addToSABnzbdFromYubse(node) {
 
 function handleAllDownloadLinks() {
 	$('.header_btn a:last-child').after(function() {
-		var img = chrome.extension.getURL('/images/sab2_16.png');
+		var img = chrome.runtime.getURL('/images/sab2_16.png');
 	    var href = $(this).attr('href');
 	    var link = '<a class="addSABnzbd"><img title="Send to SABnzbd" style="margin-top:-20px;" align="absmiddle"  src="' + img + '"/></a> ';
 	    $(this).after(link);
@@ -66,7 +66,7 @@ function handleAllDownloadLinks() {
 function handleSingleDownloadLink(node) {
 	if ($(node).find('a[class="addSABnzbd"]').length==0){
 		$(node).find('input').each(function() {
-			var img = chrome.extension.getURL('/images/sab2_16.png');
+			var img = chrome.runtime.getURL('/images/sab2_16.png');
 			var href = $(this).attr('href');
 			var link = '<td class="addSABnzbd"><a class="addSABnzbd"><img style="margin-top:3px" title="Send to SABnzbd" align="absmiddle"  src="' + img + '"/></a></td> ';
 			$(this).parent().parent().find('td:last').after(link);

--- a/scripts/pages/background.js
+++ b/scripts/pages/background.js
@@ -351,7 +351,7 @@ function sendSabRequest( params, success_callback, error_callback, profileValues
 
 function updatePopup()
 {
-	var views = chrome.extension.getViews({ type: "popup" });
+	var views = chrome.runtime.getViews({ type: "popup" });
 	if( views.length == 1 )
 	{
 		var popup = views[0];
@@ -585,7 +585,7 @@ function initializeProfile()
 
 function initializeBackgroundPage()
 {
-	chrome.extension.onMessage.addListener( OnRequest );
+	chrome.runtime.onMessage.addListener( OnRequest );
 
     // Migration from localStorage to chrome.storage.sync
 	var settingsSynced = store.get( 'settings_synced' );

--- a/scripts/pages/context_menu.js
+++ b/scripts/pages/context_menu.js
@@ -22,7 +22,7 @@ function ContextClicked( info, tab )
 
 function CreateContextMenuResult()
 {
-	var error = chrome.extension.lastError;
+	var error = chrome.runtime.lastError;
 	if( error )
 	{
 		alert(

--- a/scripts/pages/newznab-autoadd.js
+++ b/scripts/pages/newznab-autoadd.js
@@ -47,7 +47,7 @@
                 setting: 'nabignore.' + thishost,
                 value: true
             };
-            chrome.extension.sendMessage( request );
+            chrome.runtime.sendMessage( request );
             $('a.close').click();
         });
         $('#autonabEnable').click(function(){
@@ -55,13 +55,13 @@
                 action: 'get_setting',
                 setting: 'provider_newznab'
             };
-            chrome.extension.sendMessage( request, function( response ) {
+            chrome.runtime.sendMessage( request, function( response ) {
                 var request = {
                     action: 'set_setting',
                     setting: 'provider_newznab',
                     value: response.value + ', ' + thishost
                 };
-                chrome.extension.sendMessage( request, function() {
+                chrome.runtime.sendMessage( request, function() {
                     location.reload();
                 });
             });

--- a/scripts/pages/popup.js
+++ b/scripts/pages/popup.js
@@ -203,11 +203,11 @@ function SetupTogglePause() {
 	paused = getPref('paused');
 
 	if (paused) {
-		var playImg = chrome.extension.getURL('images/control_play.png');
+		var playImg = chrome.runtime.getURL('images/control_play.png');
 		var img = '<img src="' + playImg +'" />';
 		var msg = 'Resume Queue';
 	} else {
-		var pauseImg = chrome.extension.getURL('images/control_pause.png');
+		var pauseImg = chrome.runtime.getURL('images/control_pause.png');
 		var img = '<img src="' + pauseImg +'" />';
 		var msg = 'Pause Queue';
 	}
@@ -300,9 +300,9 @@ function reDrawPopup() {
 	}
 	
 	var data = {
-		'playImg':chrome.extension.getURL('images/control_play.png'),
-		'pauseImg':chrome.extension.getURL('images/control_pause.png'),
-		'deleteImg':chrome.extension.getURL('images/messagebox_critical.png')
+		'playImg':chrome.runtime.getURL('images/control_play.png'),
+		'pauseImg':chrome.runtime.getURL('images/control_pause.png'),
+		'deleteImg':chrome.runtime.getURL('images/messagebox_critical.png')
 	};
 	
 	// Grab a list of jobs (array of slot objects from the json API)
@@ -465,7 +465,7 @@ function OnProfileChanged( event )
 	var profileName = event.target.value;
 	profiles.setActiveProfile( profileName );
 	
-	var tabs = chrome.extension.getViews( {type: 'tab'} );
+	var tabs = chrome.runtime.getViews( {type: 'tab'} );
 	for( var t in tabs ) {
 		var tab = tabs[t];
 		if( tab.is_sabconnect_settings ) {
@@ -504,7 +504,7 @@ function populateAndSetCategoryList()
     var params = {
         action: 'get_categories'
     }
-    chrome.extension.sendMessage(params, function(data) {
+    chrome.runtime.sendMessage(params, function(data) {
         for (i = 0; i < data.categories.length; i++) {
             var cat = '<option value="' + data.categories[i] + '">' + data.categories[i] + '</option>';
             $('#userCategory').append(cat);


### PR DESCRIPTION
Chrome 58 has deprecated a lot of the chrome.extension API in favor of the chrome.runtime API. Mostly chrome.extension.getURL and chrome.extension.onMessage were the issue. The latest version of Chrome broke the chrome.extension.onMessage call which manifested as Initializer not defined in the console.