### PR TITLE
dognzb - Replace spinner with checkmark after successfully sent to Sabnzbd

### DIFF
--- a/scripts/content/common.js
+++ b/scripts/content/common.js
@@ -35,6 +35,12 @@ function onResponseAdd( response, addLink )
 			$(addLink).find('img').attr("src", img);
 		} else if (addLink.nodeName && addLink.nodeName.toUpperCase() == 'INPUT' && addLink.value == 'Sent to SABnzbd!') {
 			// Nothing; handled in nzbsorg.js
+		} else if ($(addLink).find('i').length > 0) {
+			// Handle Font Awesome icons (e.g., DogNZB)
+			var icon = $(addLink).find('i');
+			if (icon.hasClass('fa-spinner') && icon.hasClass('fa-spin')) {
+				icon.removeClass('fa-spinner').removeClass('fa-spin').addClass('fa-check');
+			}
 		} else {
 			// Prevent updating the background image of Bootstrap buttons
 			if ($(addLink).hasClass('btn') == false) { 


### PR DESCRIPTION
Replaces the spinner with a checkmark after the nzb has been successfully sent to Sabnzbd in dognzb 2.0

<img width="406" height="50" alt="image" src="https://github.com/user-attachments/assets/542cc08b-97d7-44c6-810d-f6294e0b1928" />